### PR TITLE
chore(release): bump to v1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashkeys",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dashkeys",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@dashincubator/secp256k1": "^1.7.1-5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashkeys",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Generate, validate, create, and convert WIFs and PayAddress.",
   "main": "dashkeys.js",
   "bin": {},


### PR DESCRIPTION
Published v1.0.1 to NPM to fix `require` issue in ESM module, this gets main branch up to date.