### PR TITLE
ref!: drop node:crypto

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,22 @@
+name: Node.js CI
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version:
+          - 20.x
+          - latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm run fmt
+    - run: npm ci
+    - run: npm test

--- a/dashkeys.js
+++ b/dashkeys.js
@@ -95,7 +95,7 @@ var DashKeys = ("object" === typeof module && exports) || {};
   const TPUB = "043587cf";
 
   /** @type {typeof window.crypto} */
-  let Crypto = Window.crypto || require("node:crypto");
+  let Crypto = globalThis.crypto;
   let Utils = {};
 
   /** @type {Uint8ArrayToHex} */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashkeys",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dashkeys",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@dashincubator/secp256k1": "^1.7.1-5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashkeys",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dashkeys",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@dashincubator/base58check": "^1.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,17 @@
       "version": "1.0.3",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
+        "@dashincubator/base58check": "^1.3.2",
         "@dashincubator/secp256k1": "^1.7.1-5"
+      }
+    },
+    "node_modules/@dashincubator/base58check": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@dashincubator/base58check/-/base58check-1.3.2.tgz",
+      "integrity": "sha512-Bx/Zu/EHeI4yCsiEhvPe0eYkNuU3NUZfNl07T0XwMnRb8LWJj2IX9FpwhQWJA0t/Vrpfz7gr0JmhY58Cez2Cpw==",
+      "dev": true,
+      "bin": {
+        "base58check": "bin/base58check.js"
       }
     },
     "node_modules/@dashincubator/secp256k1": {
@@ -20,6 +30,12 @@
     }
   },
   "dependencies": {
+    "@dashincubator/base58check": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@dashincubator/base58check/-/base58check-1.3.2.tgz",
+      "integrity": "sha512-Bx/Zu/EHeI4yCsiEhvPe0eYkNuU3NUZfNl07T0XwMnRb8LWJj2IX9FpwhQWJA0t/Vrpfz7gr0JmhY58Cez2Cpw==",
+      "dev": true
+    },
     "@dashincubator/secp256k1": {
       "version": "1.7.1-5",
       "resolved": "https://registry.npmjs.org/@dashincubator/secp256k1/-/secp256k1-1.7.1-5.tgz",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "bump": "npm version -m \"chore(release): bump to v%s\"",
     "fmt": "npx -p prettier@2.x -- prettier -w '**/*.{html,js,md}'",
     "lint": "npx -p typescript@4.x -- tsc -p ./jsconfig.json",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node ./test.js"
   },
   "repository": {
     "type": "git",
@@ -41,6 +41,7 @@
   },
   "homepage": "https://github.com/dashhive/dashkeys.js#readme",
   "devDependencies": {
+    "@dashincubator/base58check": "^1.3.2",
     "@dashincubator/secp256k1": "^1.7.1-5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashkeys",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Generate, validate, create, and convert WIFs and PayAddress.",
   "main": "dashkeys.js",
   "browser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashkeys",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Generate, validate, create, and convert WIFs and PayAddress.",
   "main": "dashkeys.js",
   "browser": {


### PR DESCRIPTION
We only support node v18+ now because of its compatibility with WebCrypto.

It also exposes `globalThis.crypto` as WebCrypto - no need for `require('node:crypto')`.