### PR TITLE
fix: pass version opts down to Base58Check

### DIFF
--- a/base58check.types.js
+++ b/base58check.types.js
@@ -125,13 +125,23 @@ module.exports._types = true;
 /**
  * @callback Decode
  * @param {String} base58check - WIF, Payment Address, xPrv, or xPub
+ * @param {Object} opts
+ * @param {[String, String]} opts.versions
+ * @param {[String, String]} opts.xversions
  * @returns {Parts}
  */
 
 /**
  * @callback DecodeHex
  * @param {String} hex - magic version bytes + data + checksum
+ * @param {DecodeOpts} [opts]
  * @returns {Parts}
+ */
+
+/**
+ * @typedef DecodeOpts
+ * @prop {[String, String]} [versions]
+ * @prop {[String, String]} [xversions]
  */
 
 /**
@@ -153,6 +163,8 @@ module.exports._types = true;
 /**
  * @typedef VerifyOpts
  * @prop {Boolean} [verify] - set 'false' to set 'valid' false rather than throw
+ * @param {[String, String]} [versions]
+ * @param {[String, String]} [xversions]
  */
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashkeys",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dashkeys",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@dashincubator/base58check": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashkeys",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Generate, validate, create, and convert WIFs and PayAddress.",
   "main": "dashkeys.js",
   "browser": {


### PR DESCRIPTION
Since DashKeys is a singleton (probably a poor choice on my part, but in line with our original goal of only supporting Dash), there's only one instance of Base58Check version.

This modifies the `base58Check` instance to accept `opts = { versrions, xversions }`.